### PR TITLE
Skip github token check when not pushing

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -205,14 +205,14 @@ if [ "$INPUT_UPLOAD_TRANSLATIONS" = true ]; then
 fi
 
 if [ "$INPUT_DOWNLOAD_TRANSLATIONS" = true ]; then
-  [ -z "${GITHUB_TOKEN}" ] && {
-    echo "CAN NOT FIND 'GITHUB_TOKEN' IN ENVIRONMENT VARIABLES"
-    exit 1
-  }
-
   download_translations
 
   if [ "$INPUT_PUSH_TRANSLATIONS" = true ]; then
+    [ -z "${GITHUB_TOKEN}" ] && {
+      echo "CAN NOT FIND 'GITHUB_TOKEN' IN ENVIRONMENT VARIABLES"
+      exit 1
+    }
+
     push_to_branch
   fi
 fi


### PR DESCRIPTION
Hey.

According to the source of `entrypoint.sh`, `GITHUB_TOKEN` is used only for `push_to_branch()` routine which is **not** called when `push_translations` is set to `false`. Therefore, it shouldn't be required to specify github token in this case, as it's not used at all, even if provided.

This follows on existing expectation of not requiring `GITHUB_TOKEN` e.g. for uploading, which also doesn't use the token anywhere.

Thank you for considering this enhancement.