### PR TITLE
Add possibility to configure base branch

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ In case you don’t want to download translations from Crowdin (`download_transl
   with:
     # upload sources option
     upload_sources: true
-    
+
     # upload translations options
     upload_translations: true
     upload_language: 'uk'
@@ -80,6 +80,9 @@ In case you don’t want to download translations from Crowdin (`download_transl
     pull_request_title: 'New Crowdin translations'
     pull_request_body: 'New Crowdin pull request with translations'
     pull_request_labels: 'enhancement, good first issue'
+    # This is the name of the git branch to with pull request will be created.
+    # If not specified default repository branch will be used.
+    pull_request_base_branch_name: not_default_branch
 
     # global options
 

--- a/action.yml
+++ b/action.yml
@@ -76,6 +76,9 @@ inputs:
   pull_request_labels:
     description: 'To add labels for created pull request'
     required: false
+  pull_request_base_branch_name:
+    description: 'Create pull request to specified branch instead of default one'
+    required: false
 
   # global options
   crowdin_branch_name:

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -114,8 +114,12 @@ create_pull_request() {
   HEADER="Accept: application/vnd.github.v3+json; application/vnd.github.antiope-preview+json; application/vnd.github.shadow-cat-preview+json"
 
   REPO_URL="https://api.github.com/repos/${GITHUB_REPOSITORY}"
-  REPO_RESPONSE=$(curl -sSL -H "${AUTH_HEADER}" -H "${HEADER}" -X GET "${REPO_URL}")
-  BASE_BRANCH=$(echo "${REPO_RESPONSE}" | jq --raw-output '.default_branch')
+  if [ -n "$INPUT_PULL_REQUEST_BASE_BRANCH_NAME" ];then
+    BASE_BRANCH="$INPUT_PULL_REQUEST_BASE_BRANCH_NAME"
+  else
+    REPO_RESPONSE=$(curl -sSL -H "${AUTH_HEADER}" -H "${HEADER}" -X GET "${REPO_URL}")
+    BASE_BRANCH=$(echo "${REPO_RESPONSE}" | jq --raw-output '.default_branch')
+  fi
 
   PULLS_URL="${REPO_URL}/pulls"
 


### PR DESCRIPTION
This adds possibility to maintain different translations sets
for different project branches.
Currently you can create separate workflows for separate branches,
and use different localization branches for them,
but it will always create pull request to default selected branch.
This commit allows to override base branch using default branch
when this options isn't specified