### PR TITLE
fix: Ignore githooks

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -181,8 +181,8 @@ push_to_branch() {
     echo "PUSH TO BRANCH ${LOCALIZATION_BRANCH}"
 
     git add .
-    git commit -m "${INPUT_COMMIT_MESSAGE}"
-    git push --force "${REPO_URL}"
+    git commit --no-verify -m "${INPUT_COMMIT_MESSAGE}"
+    git push --no-verify --force "${REPO_URL}"
 
     if [ "$INPUT_CREATE_PULL_REQUEST" = true ]; then
       create_pull_request "${LOCALIZATION_BRANCH}"


### PR DESCRIPTION
When using [githooks](https://git-scm.com/docs/githooks), the action will sometimes fail because it can't find a specified file ([in our case](https://github.com/wireapp/wire-webapp/runs/1886243058#step:9:83), it was `npx`).

This will use git's `--no-verify` option to ignore githooks.