### PR TITLE
Bugfix for GPG key import

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ jobs:
       uses: actions/checkout@v2
 
     - name: crowdin action
-      uses: crowdin/github-action@1.3.0
+      uses: crowdin/github-action@1.3.1
       with:
         upload_translations: true
         download_translations: true
@@ -100,6 +100,10 @@ In case you don’t want to download translations from Crowdin (`download_transl
     github_api_base_url: api.[github_base_url]
     github_user_name: Crowdin Bot
     github_user_email: support+bot@crowdin.com
+    
+    # For signed commits, add your ASCII-armored key
+    # Ensure that all emails are the same: for account profile that holds public key, the one specified during key generation, and for commit author (github_user_email parameter)
+    gpg_private_key: ${{ secrets.GPG_PRIVATE_KEY }}
 
     # config options
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -153,7 +153,7 @@ setup_commit_signing() {
 
   gpg --import private.key
 
-  GPG_KEY_ID=$(gpg --list-secret-keys --keyid-format=long | grep -o "rsa\d\+\/\(\w\+\)" | head -n1 | sed "s/rsa\d\+\/\(\d\+\)/\1/")
+  GPG_KEY_ID=$(gpg --list-secret-keys --keyid-format=long | grep -o "rsa\d\+\/\(\w\+\)" | head -n1 | sed "s/rsa\d\+\/\(\w\+\)/\1/")
   GPG_KEY_OWNER_NAME=$(gpg --list-secret-keys --keyid-format=long | grep  "uid" | sed "s/.\+] \(.\+\) <\(.\+\)>/\1/")
   GPG_KEY_OWNER_EMAIL=$(gpg --list-secret-keys --keyid-format=long | grep  "uid" | sed "s/.\+] \(.\+\) <\(.\+\)>/\2/")
   echo "Imported key information:"


### PR DESCRIPTION
Minor changes regarding signing commits.

- fixes an issue when GPG key id starts with a letter it can't be imported
- updated README about using the signed commits feature
- assuming this will be version 1.3.1, specified it in the instructions