### PR TITLE
fix incorrect params for GET /pulls

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -79,9 +79,9 @@ create_pull_request() {
     BASE_BRANCH="${GITHUB_REF#refs/heads/}"
   fi
 
-  PULL_REQUESTS_DATA="{\"base\":\"${BASE_BRANCH}\", \"head\":\"${LOCALIZATION_BRANCH}\"}"
+  PULL_REQUESTS_QUERY_PARAMS="?base=${BASE_BRANCH}&head=${LOCALIZATION_BRANCH}"
 
-  PULL_REQUESTS=$(echo "$(curl -sSL -H "${AUTH_HEADER}" -H "${HEADER}" -X GET --data "${PULL_REQUESTS_DATA}" "${PULLS_URL}")" | jq --raw-output '.[] | .head.ref ')
+  PULL_REQUESTS=$(echo "$(curl -sSL -H "${AUTH_HEADER}" -H "${HEADER}" -X GET "${PULLS_URL}${PULL_REQUESTS_QUERY_PARAMS}")" | jq --raw-output '.[] | .head.ref ')
 
   if echo "$PULL_REQUESTS " | grep -q "$LOCALIZATION_BRANCH "; then
     echo "PULL REQUEST ALREADY EXIST"


### PR DESCRIPTION
Github documentation reference: https://docs.github.com/en/rest/reference/pulls#list-pull-requests

`GET /repos/{owner}/{repo}/pulls` does not take a JSON body. Instead, the options must be sent as query parameters.