### PR TITLE
Check status once again before committing

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -153,6 +153,12 @@ push_to_branch() {
     echo "PUSH TO BRANCH ${LOCALIZATION_BRANCH}"
 
     git add .
+
+    if [ ! -n "$(git status -s)" ]; then
+      echo "NOTHING TO COMMIT"
+      return
+    fi
+
     git commit --no-verify -m "${INPUT_COMMIT_MESSAGE}"
     git push --no-verify --force "${REPO_URL}"
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -149,24 +149,19 @@ push_to_branch() {
     git checkout -b "${LOCALIZATION_BRANCH}"
   fi
 
-  if [ -n "$(git status -s)" ]; then
-    echo "PUSH TO BRANCH ${LOCALIZATION_BRANCH}"
+  git add .
 
-    git add .
-
-    if [ ! -n "$(git status -s)" ]; then
-      echo "NOTHING TO COMMIT"
-      return
-    fi
-
-    git commit --no-verify -m "${INPUT_COMMIT_MESSAGE}"
-    git push --no-verify --force "${REPO_URL}"
-
-    if [ "$INPUT_CREATE_PULL_REQUEST" = true ]; then
-      create_pull_request "${LOCALIZATION_BRANCH}"
-    fi
-  else
+  if [ ! -n "$(git status -s)" ]; then
     echo "NOTHING TO COMMIT"
+    return
+  fi
+
+  echo "PUSH TO BRANCH ${LOCALIZATION_BRANCH}"
+  git commit --no-verify -m "${INPUT_COMMIT_MESSAGE}"
+  git push --no-verify --force "${REPO_URL}"
+
+  if [ "$INPUT_CREATE_PULL_REQUEST" = true ]; then
+    create_pull_request "${LOCALIZATION_BRANCH}"
   fi
 }
 


### PR DESCRIPTION
Hello Crowdin folks!

The reason for that is that some users may want to remove all
translation before downloading them again, for instance, to make sure
there are no stale translations.

When that is the case, the first check will indicate there are changes,
since files were removed.

However, when the download files are the same as the files that were
previously removed, `git add .` will cause the next `git status -s` to
be clean. If the second check is not in place, the script will attempt
to commit the changes, but as there are none, the action will fail,
instead of just being skipped.

Snippet of a config we are using:

```yaml
name: Crowdin Sync

on:
  push:
    branches: [main]

jobs:
  sync_with_crowdin:
    name: Sync with Crowdin
    if: github.repository == 'github/docs-internal-downsized'
    runs-on: ubuntu-latest
    steps:
      - name: Checkout
        uses: actions/checkout@1e204e9a9253d643386038d443f96446fa156a97
        with:
          fetch-depth: 0
          lfs: true

      # This will cause git status to be dirty, no matter what
      - name: Remove all translations
        run: git rm -rf --quiet translations/*/content

      - name: Sync
        uses: mjacobus/github-action@d087d57f31ccaa817e95e626ee199e6e5b839159
        with: "..."
```

The last lines of the output

```
Your branch is up to date with 'origin/remove-all-files-before-sync'.
+ git show-ref refs/heads/translations
+ '[' -n  ]
+ git checkout -b translations
Switched to a new branch 'translations'
+ git status -s
+ '[' -n 'D  translations/pt-BR/content/dummy/foo/index.md
D  translations/pt-BR/content/dummy/foo/new-bar.md
D  translations/pt-BR/content/dummy/index.md
D  translations/pt-BR/content/index.md
?? translations/pt-BR/content/' ]
+ echo 'PUSH TO BRANCH translations'
+ git add .
PUSH TO BRANCH translations
+ git status -s
+ '[' '!' -n  ]
NOTHING TO COMMIT
+ echo 'NOTHING TO COMMIT'
+ return
+ '[' -n  ]
```