### PR TITLE
Fix for Git v2.35.2 spec changes

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -204,6 +204,10 @@ get_branch_available_options() {
 
 echo "STARTING CROWDIN ACTION"
 
+cd "${GITHUB_WORKSPACE}" || exit 1
+
+git config --global --add safe.directory $GITHUB_WORKSPACE
+
 view_debug_output
 
 set -e


### PR DESCRIPTION
The GitHub Action fails to create a pull request due to Git v2.35.2 spec changes.

More info and should fix https://github.com/crowdin/github-action/issues/114

I have tested my fork in a private repository and it worked as expected after this patch.