### PR TITLE
Updated descriptions for base_path and source

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,7 +136,7 @@ In case you don’t want to download translations from Crowdin (`download_transl
     source: 'path/to/your/file'
     translation: 'file/export/pattern'
     base_url: 'https://crowdin.com'
-    base_path: '/project-base-path'
+    base_path: 'project-base-path'
 ```
 
 **Note:** For Crowdin Enterprise `base_url` is required and should be passed in the following way: `base_url: 'https://{organization-name}.crowdin.com'`

--- a/action.yml
+++ b/action.yml
@@ -156,10 +156,10 @@ inputs:
     description: 'Base URL of Crowdin server for API requests execution'
     required: false
   base_path:
-    description: 'Path to your project directory on a local machine'
+    description: 'Path to your project directory on a local machine, without / at the beginning'
     required: false
   source:
-    description: 'Path to the source files'
+    description: 'Path to the source files, without / at the beginning'
     required: false
   translation:
     description: 'Path to the translation files'


### PR DESCRIPTION
Hey there, 

I was setting up my crowdin github actions and noticed this, so I thought I'd update the descriptions. 😊

The action failed when starting with a "/". For example:
`source: "/src/i18n/languages/en/**/*.*"` - action failed ❌

Removing the "/" solved it:
`source: "src/i18n/languages/en/**/*.*"` - works! ✅

* Same thing for the `base_path` as well.