### PR TITLE
Don't check out GITHUB_REF in push_to_branch()

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -142,10 +142,6 @@ push_to_branch() {
   git config --global user.email "${INPUT_GITHUB_USER_EMAIL}"
   git config --global user.name "${INPUT_GITHUB_USER_NAME}"
 
-  if [ ${GITHUB_REF#refs/heads/} != $GITHUB_REF ]; then
-    git checkout "${GITHUB_REF#refs/heads/}"
-  fi
-
   if [ -n "$(git show-ref refs/heads/${LOCALIZATION_BRANCH})" ]; then
     git checkout "${LOCALIZATION_BRANCH}"
   else


### PR DESCRIPTION
This makes it possible to run this action on multiple branches in the same workflow.