### PR TITLE
Assign users to PR via pull_request_assignees

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ In case you don’t want to download translations from Crowdin (`download_transl
     pull_request_title: 'New Crowdin translations'
     pull_request_body: 'New Crowdin pull request with translations'
     pull_request_labels: 'enhancement, good first issue'
-    pull_request_assignees: 'crowdin, hubot'
+    pull_request_assignees: 'crowdin-bot'
     # This is the name of the git branch to with pull request will be created.
     # If not specified default repository branch will be used.
     pull_request_base_branch_name: not_default_branch

--- a/README.md
+++ b/README.md
@@ -96,6 +96,7 @@ In case you don’t want to download translations from Crowdin (`download_transl
     pull_request_title: 'New Crowdin translations'
     pull_request_body: 'New Crowdin pull request with translations'
     pull_request_labels: 'enhancement, good first issue'
+    pull_request_assignees: 'crowdin, hubot'
     # This is the name of the git branch to with pull request will be created.
     # If not specified default repository branch will be used.
     pull_request_base_branch_name: not_default_branch

--- a/action.yml
+++ b/action.yml
@@ -82,7 +82,7 @@ inputs:
     description: 'The contents of the pull request'
     required: false
   pull_request_assignees:
-    description: 'Add up to 10 assignees to the created pull request'
+    description: 'Add up to 10 assignees to the created pull request (separated by comma)'
     required: false
   pull_request_labels:
     description: 'To add labels for created pull request'

--- a/action.yml
+++ b/action.yml
@@ -81,6 +81,9 @@ inputs:
   pull_request_body:
     description: 'The contents of the pull request'
     required: false
+  pull_request_assignees:
+    description: 'Add up to 10 assignees to the created pull request'
+    required: false
   pull_request_labels:
     description: 'To add labels for created pull request'
     required: false

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -129,6 +129,23 @@ create_pull_request() {
       fi
     fi
 
+    if [ -n "$INPUT_PULL_REQUEST_ASSIGNEES" ]; then
+      PULL_REQUEST_ASSIGNEES=$(echo "[\"${INPUT_PULL_REQUEST_ASSIGNEES}\"]" | sed 's/, \|,/","/g')
+
+      if [ "$(echo "$PULL_REQUEST_ASSIGNEES" | jq -e . > /dev/null 2>&1; echo $?)" -eq 0 ]; then
+        echo "ADD ASSIGNEES TO PULL REQUEST"
+
+        ASSIGNEES_URL="${REPO_URL}/issues/${PULL_REQUESTS_NUMBER}/assignees"
+
+        ASSIGNEES_DATA="{\"assignees\":${PULL_REQUEST_ASSIGNEES}}"
+
+        # add assignees to created pull request
+        curl -sSL -H "${AUTH_HEADER}" -H "${HEADER}" -X POST --data "${ASSIGNEES_DATA}" "${ASSIGNEES_URL}"
+      else
+        echo "JSON OF pull_request_assignees IS INVALID: ${PULL_REQUEST_ASSIGNEES}"
+      fi
+    fi
+
     echo "PULL REQUEST CREATED: ${PULL_REQUESTS_URL}"
   fi
 }


### PR DESCRIPTION
Opening this to get feedback on the addition of a new option `pull_request_assignees` which will assign the created pull request to users. This is based on the label functionality added in https://github.com/crowdin/github-action/pull/25 by @VBeytok 🙂  

The use-case is adding specific assignees that will review the created pull request. A workaround without this functionality is to use a [CODEOWNERS](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners#codeowners-syntax) file.

This is optional, if this doesn't add value please feel free to close this PR; otherwise happy to discuss any improvements to the code, the `create_pull_request` function is getting pretty large at this point.