### PR TITLE
Add authentication check

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -77,6 +77,12 @@ create_pull_request() {
 
   PULLS_URL="${REPO_URL}/pulls"
 
+  auth_status=$(curl -sL --write-out '%{http_code}' --output /dev/null -H "${AUTH_HEADER}" -H "${HEADER}" "${PULLS_URL}")
+  if [[ $auth_status -eq 403 || "$auth_status" -eq 401 ]] ; then
+    echo "FAILED TO AUTHENTICATE USING 'GITHUB_TOKEN' CHECK TOKEN IS VALID"
+    exit 1
+  fi
+
   echo "CHECK IF ISSET SAME PULL REQUEST"
 
   if [ -n "$INPUT_PULL_REQUEST_BASE_BRANCH_NAME" ]; then


### PR DESCRIPTION
This adds an authentication check before attempting to create a pull request via the action. If the check fails we do not proceed to create a pull request. It provides a useful error message when reviewing the action logs.

When running this action I noticed the following error when a `GITHUB_TOKEN` expires:

```
jq: error (at <stdin>:4): Cannot index string with string "head"
```

This is caused by an attempt to get the head ref when the API responds with an error:

```
{ "message": "Bad credentials", "documentation_url": "https://docs.github.com/rest" }
```

https://github.com/crowdin/github-action/blob/ec22a497e86e368978394007ad718f9bbfdc396c/entrypoint.sh#L100

