### PR TITLE
Version v1.6.0

### DIFF
--- a/.github/workflows/update-main-version.yml
+++ b/.github/workflows/update-main-version.yml
@@ -1,0 +1,34 @@
+name: Update Main Version
+
+run-name: Move ${{ github.event.inputs.main_version }} to ${{ github.event.inputs.target }}
+
+on:
+  workflow_dispatch:
+    inputs:
+      target:
+        description: The tag or reference to use
+        required: true
+      main_version:
+        type: choice
+        description: The main version to update
+        options:
+          - v1
+
+jobs:
+  tag:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+
+      - name: Git config
+        run: |
+          git config user.name github-actions
+          git config user.email github-actions@github.com
+
+      - name: Tag new target
+        run: git tag -f ${{ github.event.inputs.main_version }} ${{ github.event.inputs.target }}
+
+      - name: Push new tag
+        run: git push origin ${{ github.event.inputs.main_version }} --force

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM crowdin/cli:3.9.3
+FROM crowdin/cli:3.10.0
 
 RUN apk --no-cache add curl git git-lfs jq gnupg;
 

--- a/EXAMPLES.md
+++ b/EXAMPLES.md
@@ -36,7 +36,7 @@ jobs:
       uses: actions/checkout@v3
 
     - name: Synchronize with Crowdin
-      uses: crowdin/github-action@1.5.3
+      uses: crowdin/github-action@v1
       with:
         upload_sources: true
         upload_translations: true
@@ -70,7 +70,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Synchronize with Crowdin
-        uses: crowdin/github-action@1.5.3
+        uses: crowdin/github-action@v1
         with:
           upload_sources: true
           upload_translations: false
@@ -102,7 +102,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Crowdin sync
-        uses: crowdin/github-action@1.5.3
+        uses: crowdin/github-action@v1
         with:
           upload_sources: true
           upload_translations: false
@@ -135,7 +135,7 @@ jobs:
       uses: actions/checkout@v3
 
     - name: Crowdin push
-      uses: crowdin/github-action@1.5.3
+      uses: crowdin/github-action@v1
       with:
         upload_sources: true
         upload_translations: false
@@ -162,7 +162,7 @@ jobs:
       uses: actions/checkout@v3
 
     - name: Crowdin push
-      uses: crowdin/github-action@1.5.3
+      uses: crowdin/github-action@v1
       with:
         upload_sources: true
         upload_translations: false
@@ -193,7 +193,7 @@ jobs:
       uses: actions/checkout@v3
 
     - name: Crowdin pull
-      uses: crowdin/github-action@1.5.3
+      uses: crowdin/github-action@v1
       with:
         upload_sources: false
         upload_translations: false
@@ -224,7 +224,7 @@ jobs:
       uses: actions/checkout@v3
 
     - name: Synchronize with Crowdin
-      uses: crowdin/github-action@1.5.3
+      uses: crowdin/github-action@v1
       with:
         upload_sources: true
         upload_translations: true
@@ -251,7 +251,7 @@ jobs:
 ...
 
 - name: Crowdin
-  uses: crowdin/github-action@1.5.3
+  uses: crowdin/github-action@v1
   with:
     config: '.github/crowdin.yml'
 
@@ -282,7 +282,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Matrix
-        uses: crowdin/github-action@1.5.3
+        uses: crowdin/github-action@v1
         with:
           upload_sources: false
           upload_translations: false

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ jobs:
       uses: actions/checkout@v3
 
     - name: crowdin action
-      uses: crowdin/github-action@1.5.3
+      uses: crowdin/github-action@v1
       with:
         upload_translations: true
         download_translations: true


### PR DESCRIPTION
- Bump CLI version
- Add 'update-main-version' GitHub Workflow
- Use the 'v1' version in the examples
