### PR TITLE
feat: add support for team review requests

### DIFF
--- a/EXAMPLES.md
+++ b/EXAMPLES.md
@@ -243,7 +243,8 @@ jobs:
 
           pull_request_labels: 'enhancement, good first issue'
           pull_request_assignees: 'crowdin-bot'
-          pull_request_reviewers: 'crowdin-reviewer'
+          pull_request_reviewers: 'crowdin-user-reviewer'
+          pull_request_team_reviewers: 'crowdin-team-reviewer'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           CROWDIN_PROJECT_ID: ${{ secrets.CROWDIN_PROJECT_ID }}

--- a/README.md
+++ b/README.md
@@ -125,7 +125,9 @@ In case you don’t want to download translations from Crowdin (`download_transl
     pull_request_body: 'New Crowdin pull request with translations'
     pull_request_labels: 'enhancement, good first issue'
     pull_request_assignees: 'crowdin-bot'
-    pull_request_reviewers: 'crowdin-reviewer'
+    pull_request_reviewers: 'crowdin-user-reviewer'
+    pull_request_team_reviewers: 'crowdin-team-reviewer'
+
     # This is the name of the git branch to with pull request will be created.
     # If not specified default repository branch will be used.
     pull_request_base_branch_name: not_default_branch

--- a/action.yml
+++ b/action.yml
@@ -102,7 +102,7 @@ inputs:
     description: 'Usernames of people from whom a review is requested for this pull request (separated by comma)'
     required: false
   pull_request_team_reviewers:
-    description: 'Team names from which a review is requested for this pull request (separated by comma)'
+    description: 'Team slugs from which a review is requested for this pull request (separated by comma)'
     required: false
   pull_request_labels:
     description: 'To add labels for created pull request'

--- a/action.yml
+++ b/action.yml
@@ -101,6 +101,9 @@ inputs:
   pull_request_reviewers:
     description: 'Usernames of people from whom a review is requested for this pull request (separated by comma)'
     required: false
+  pull_request_team_reviewers:
+    description: 'Team names from which a review is requested for this pull request (separated by comma)'
+    required: false
   pull_request_labels:
     description: 'To add labels for created pull request'
     required: false


### PR DESCRIPTION
This PR adds the new input argument `pull_request_team_reviewers`.  [GitHub's API to request reviewers takes different arguments for users and teams](https://docs.github.com/en/rest/pulls/review-requests?apiVersion=2022-11-28#request-reviewers-for-a-pull-request), for example:

```
curl -L \
  -X POST \
  -H "Accept: application/vnd.github+json" \
  -H "Authorization: Bearer <YOUR-TOKEN>" \
  -H "X-GitHub-Api-Version: 2022-11-28" \
  https://api.github.com/repos/OWNER/REPO/pulls/PULL_NUMBER/requested_reviewers \
  -d '{"reviewers":["octocat","hubot","other_user"],"team_reviewers":["justice-league"]}'
```

With these changes, PRs opened by this action can now have requested reviews from users and/or teams. Both are optional. 

Documentation has also been updated to include the new argument.

