### PR TITLE
feat: add output letting users know if a pull request was created or not

### DIFF
--- a/README.md
+++ b/README.md
@@ -195,6 +195,12 @@ api_token_env: CROWDIN_PERSONAL_TOKEN
 
 When the workflow runs, the real values of your token and project ID will be injected into the config using the secrets in the environment.
 
+## Outputs
+
+This workflow has the following outputs:
+
+- `pull_request_url`: The URL of the pull request created by the workflow
+
 ## Permissions
 
 In order to push translations and create pull requests, the Crowdin GitHub Action requires the `GITHUB_TOKEN` to have the write permission on the `content` and `pull-requests`.

--- a/README.md
+++ b/README.md
@@ -197,7 +197,7 @@ When the workflow runs, the real values of your token and project ID will be inj
 
 ## Outputs
 
-This workflow has the following outputs:
+This action has the following outputs:
 
 - `pull_request_url`: The URL of the pull request created by the workflow
 

--- a/action.yml
+++ b/action.yml
@@ -208,8 +208,8 @@ inputs:
     description: 'Additional arguments which will be passed to the Crowdin CLI command'
     required: false
 outputs:
-  pull_request_created:
-    description: 'Whether or not a pull request was created during the action run'
+  pull_request_url:
+    description: 'The URL of the pull request created by the workflow'
 
 runs:
   using: docker

--- a/action.yml
+++ b/action.yml
@@ -207,6 +207,9 @@ inputs:
   command_args:
     description: 'Additional arguments which will be passed to the Crowdin CLI command'
     required: false
+outputs:
+  pull_request_created:
+    description: 'Whether or not a pull request was created during the action run'
 
 runs:
   using: docker

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -89,6 +89,7 @@ create_pull_request() {
   auth_status=$(curl -sL --write-out '%{http_code}' --output /dev/null -H "${AUTH_HEADER}" -H "${HEADER}" "${PULLS_URL}")
   if [[ $auth_status -eq 403 || "$auth_status" -eq 401 ]] ; then
     echo "FAILED TO AUTHENTICATE USING 'GITHUB_TOKEN' CHECK TOKEN IS VALID"
+    echo "pull_request_created=false" >> $GITHUB_OUTPUT
     exit 1
   fi
 
@@ -111,6 +112,7 @@ create_pull_request() {
   # check if pull request exist
   if echo "$PULL_REQUESTS" | grep -xq "$BRANCH"; then
     echo "PULL REQUEST ALREADY EXIST"
+    echo "pull_request_created=false" >> $GITHUB_OUTPUT
   else
     echo "CREATE PULL REQUEST"
 
@@ -130,6 +132,12 @@ create_pull_request() {
     PULL_REQUESTS_URL=$(echo "${PULL_RESPONSE}" | jq '.html_url')
     PULL_REQUESTS_NUMBER=$(echo "${PULL_RESPONSE}" | jq '.number')
     view_debug_output
+
+    if [ -n "$PULL_REQUESTS_URL" ]; then
+      echo "pull_request_created=true" >> $GITHUB_OUTPUT
+    else
+      echo "pull_request_created=false" >> $GITHUB_OUTPUT
+    fi
 
     if [ "$PULL_REQUESTS_URL" = null ]; then
       echo "FAILED TO CREATE PULL REQUEST"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -136,7 +136,7 @@ create_pull_request() {
     if [ -n "$PULL_REQUESTS_URL" ]; then
       echo "pull_request_url=$PULL_REQUESTS_URL" >> $GITHUB_OUTPUT
     else
-      echo "pull_request_url=" >> $GITHUB_OUTPUT
+      echo "pull_request_url=''" >> $GITHUB_OUTPUT
     fi
 
     if [ "$PULL_REQUESTS_URL" = null ]; then

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -89,7 +89,7 @@ create_pull_request() {
   auth_status=$(curl -sL --write-out '%{http_code}' --output /dev/null -H "${AUTH_HEADER}" -H "${HEADER}" "${PULLS_URL}")
   if [[ $auth_status -eq 403 || "$auth_status" -eq 401 ]] ; then
     echo "FAILED TO AUTHENTICATE USING 'GITHUB_TOKEN' CHECK TOKEN IS VALID"
-    echo "pull_request_created=false" >> $GITHUB_OUTPUT
+    echo "pull_request_url=''" >> $GITHUB_OUTPUT
     exit 1
   fi
 
@@ -112,7 +112,7 @@ create_pull_request() {
   # check if pull request exist
   if echo "$PULL_REQUESTS" | grep -xq "$BRANCH"; then
     echo "PULL REQUEST ALREADY EXIST"
-    echo "pull_request_created=false" >> $GITHUB_OUTPUT
+    echo "pull_request_url=''" >> $GITHUB_OUTPUT
   else
     echo "CREATE PULL REQUEST"
 
@@ -134,9 +134,9 @@ create_pull_request() {
     view_debug_output
 
     if [ -n "$PULL_REQUESTS_URL" ]; then
-      echo "pull_request_created=true" >> $GITHUB_OUTPUT
+      echo "pull_request_url=$PULL_REQUESTS_URL" >> $GITHUB_OUTPUT
     else
-      echo "pull_request_created=false" >> $GITHUB_OUTPUT
+      echo "pull_request_url=" >> $GITHUB_OUTPUT
     fi
 
     if [ "$PULL_REQUESTS_URL" = null ]; then


### PR DESCRIPTION
I'm suggesting adding this output to the action for the following reasons:

When a pull request is created using the API, it does not trigger workflows listening on `pull_request`. The only way to get around this is by doing a repository dispatch and pick up on that in stead. With the added output this should be a bit more straight forward in the workflow that uses `crowdin/github-action`. 

I did not add the output in the README, as this is the first output added to the action altogether. 