### PR TITLE
docs: fix typo 'content' for GITHUB_TOKEN permission

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,7 +196,7 @@ This action has the following outputs:
 
 ## Permissions
 
-In order to push translations and create pull requests, the Crowdin GitHub Action requires the `GITHUB_TOKEN` to have the write permission on the `content` and `pull-requests`.
+In order to push translations and create pull requests, the Crowdin GitHub Action requires the `GITHUB_TOKEN` to have the write permission on the `contents` and `pull-requests`.
 
 In case you want to use an [automatic GitHub authentication token](https://docs.github.com/en/actions/security-guides/automatic-token-authentication), you need to assign the [`write` permission to your job](https://docs.github.com/en/actions/using-jobs/assigning-permissions-to-jobs) and [allow GH Actions to create Pull Requests](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/enabling-features-for-your-repository/managing-github-actions-settings-for-a-repository#preventing-github-actions-from-creating-or-approving-pull-requests).
 


### PR DESCRIPTION
In the section that describes the required permissions for the GITHUB_ACTIONS token, "Contents" is misspelled as "Content" (missing an 's').

The table of all valid permissions can be found here: https://docs.github.com/en/actions/security-guides/automatic-token-authentication#permissions-for-the-github_token