### PR TITLE
chore: deprecate the 'identity' option

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -151,6 +151,7 @@ inputs:
     required: false
   identity:
     description: 'Option to specify a path to user-specific credentials, without / at the beginning'
+    deprecationMessage: 'This option is deprecated. Please use the environment variables instead.'
     required: false
   config:
     description: 'Option to specify a path to the configuration file, without / at the beginning'


### PR DESCRIPTION
This option doesn't make much sense in the context of the GitHub action, where environment variables are a de facto standard for credentials loading. It's marked as deprecated and will be removed in the next major release.