### PR TITLE
fix: check out correct branch on pull_request events

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -230,7 +230,10 @@ push_to_branch() {
   git config --global user.name "${INPUT_GITHUB_USER_NAME}"
 
   if [ "$INPUT_SKIP_REF_CHECKOUT" != true ]; then
-    git checkout "${GITHUB_HEAD_REF:-${GITHUB_REF#refs/heads/}}"
+    CHECKOUT=${GITHUB_HEAD_REF:-${GITHUB_REF}}
+    CHECKOUT=${CHECKOUT#refs/heads/}
+    CHECKOUT=${CHECKOUT#refs/tags/}
+    git checkout "${CHECKOUT}"
   fi
 
   if [ -n "$(git show-ref refs/heads/${BRANCH})" ]; then

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -229,8 +229,8 @@ push_to_branch() {
   git config --global user.email "${INPUT_GITHUB_USER_EMAIL}"
   git config --global user.name "${INPUT_GITHUB_USER_NAME}"
 
-  if [ "$INPUT_SKIP_REF_CHECKOUT" != true ] && [ ${GITHUB_REF#refs/heads/} != $GITHUB_REF ]; then
-    git checkout "${GITHUB_REF#refs/heads/}"
+  if [ "$INPUT_SKIP_REF_CHECKOUT" != true ]; then
+    git checkout "${GITHUB_HEAD_REF:-${GITHUB_REF#refs/heads/}}"
   fi
 
   if [ -n "$(git show-ref refs/heads/${BRANCH})" ]; then


### PR DESCRIPTION
Fixes: https://github.com/crowdin/github-action/issues/242

Uses `GITHUB_HEAD_REF` if available (which points to the head on `pull_request` event triggers) and falls back to `${GITHUB_REF#refs/heads/}` or `${GITHUB_REF#refs/tags/}` otherwise.

[As per the docs](https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/store-information-in-variables), `GITHUB_REF` has 3 possible values:

- `refs/pull/<pr_number>/merge`: `pull_request` events where `GITHUB_HEAD_REF` is set to the actual head
- `refs/tags/<tag_name>`: `release` events, this PR extracts the tag_name and checks that out
- `refs/heads/<branch_name>`: all other events such as `push`

![image](https://github.com/user-attachments/assets/3bf24337-f08c-40c0-b9ab-bb99da00fd6e)
![image](https://github.com/user-attachments/assets/a38da1ac-02eb-47ae-997e-bc4774fbf9d5)
