### PR TITLE
fix: skip commit and push when no changes compared to remote

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -247,11 +247,9 @@ push_to_branch() {
     git checkout "${CHECKOUT}"
   fi
 
-  if [ -n "$(git show-ref refs/heads/${BRANCH})" ]; then
-    git checkout "${BRANCH}"
-  else
-    git checkout -b "${BRANCH}"
-  fi
+  # Checkout localization branch, using remote state if available
+  git fetch origin "${BRANCH}" 2>/dev/null || true
+  git checkout -B "${BRANCH}" "origin/${BRANCH}" 2>/dev/null || git checkout -B "${BRANCH}"
 
   git add .
 


### PR DESCRIPTION
Fetch the remote localization branch before checkout to ensure translations are compared against the actual remote state, not the base branch. This prevents unnecessary commits and force pushes when translations haven't changed.

Closes #296