### PR TITLE
feat: add user input to not create downloaded files with root owner

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM crowdin/cli:4.14.1
 
-RUN apk --no-cache add curl git git-lfs jq gnupg;
+RUN apk --no-cache add curl git git-lfs jq gnupg su-exec;
 
 COPY . .
 COPY entrypoint.sh /entrypoint.sh

--- a/README.md
+++ b/README.md
@@ -168,11 +168,12 @@ By default, the action will look for the `crowdin.yml` file in the root of the r
 
 ### Global options
 
-| Option                 | Description                                                                                | Example value              |
-|------------------------|--------------------------------------------------------------------------------------------|----------------------------|
-| `crowdin_branch_name`  | Option to upload or download files to the specified version branch in your Crowdin project | `main`                     |
-| `config`               | Option to specify a path to the configuration file (without `/` at the beginning)          | `path/to/your/crowdin.yml` |
-| `dryrun_action`        | Defines whether to run the action in the dry-run mode                                      | `false` (default)          |
+| Option                 | Description                                                                                                                           | Example value              |
+|------------------------|---------------------------------------------------------------------------------------------------------------------------------------|----------------------------|
+| `crowdin_branch_name`  | Option to upload or download files to the specified version branch in your Crowdin project                                            | `main`                     |
+| `config`               | Option to specify a path to the configuration file (without `/` at the beginning)                                                     | `path/to/your/crowdin.yml` |
+| `dryrun_action`        | Defines whether to run the action in the dry-run mode                                                                                 | `false` (default)          |
+| `user`                 | Run the action as specific user, accepts `uid:gid` or `auto` to detect from workspace ownership. Leave empty to run as root (default) | `auto`                     |
 
 ### GitHub (Enterprise) configuration
 

--- a/action.yml
+++ b/action.yml
@@ -134,6 +134,10 @@ inputs:
     description: 'Option to preview the list of managed files'
     default: 'false'
     required: false
+  user:
+    description: 'Run the action as this user (uid:gid format, e.g. "1001:1001"). Use "auto" to detect from workspace ownership. Leave empty to run as root (default).'
+    required: false
+    default: ''
 
   # GitHub (Enterprise) configuration
   github_base_url:

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,5 +1,14 @@
 #!/bin/sh
 
+# Re-execute as the specified user if running as root and INPUT_USER is set
+if [ -n "$INPUT_USER" ] && [ "$(id -u)" = "0" ]; then
+  TARGET_USER="$INPUT_USER"
+  if [ "$INPUT_USER" = "auto" ]; then
+    TARGET_USER=$(stat -c '%u:%g' "${GITHUB_WORKSPACE}/.git")
+  fi
+  exec su-exec "$TARGET_USER" "$0" "$@"
+fi
+
 # Default values for action outputs
 echo "pull_request_url=" >> $GITHUB_OUTPUT
 echo "pull_request_number=" >> $GITHUB_OUTPUT


### PR DESCRIPTION
We noticed that downloaded files are created owned by root which created a problem in our workflow, this is caused by action being a docker action and container being run by root.
There doesn't seem to be an option to specify the container user, so this PR introduces `user` input that accepts either explicit `uid:git` pair or given value `auto` will set them to the owner of `.git` and run the docker script as that user/group.