### PR TITLE
fix: support non-RSA GPG signing keys

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -337,7 +337,7 @@ setup_commit_signing() {
 
   gpg --import --batch private.key
 
-  GPG_KEY_ID=$(gpg --list-secret-keys --keyid-format=long | grep -o "rsa\d\+\/\(\w\+\)" | head -n1 | sed "s/rsa\d\+\/\(\w\+\)/\1/")
+  GPG_KEY_ID=$(gpg --with-colons --list-secret-keys | awk -F: '$1 == "sec" { print $5; exit }')
   GPG_KEY_OWNER_NAME=$(gpg --list-secret-keys --keyid-format=long | grep  "uid" | sed "s/.\+] \(.\+\) <\(.\+\)>/\1/")
   GPG_KEY_OWNER_EMAIL=$(gpg --list-secret-keys --keyid-format=long | grep  "uid" | sed "s/.\+] \(.\+\) <\(.\+\)>/\2/")
   echo "Imported key information:"


### PR DESCRIPTION
## Summary

- read the imported secret key ID from GnuPG machine-readable output
- support ed25519 and nistp384 keys without changing RSA behavior
- preserve the existing first-primary-key selection

Closes #295

## Verification

- `sh -n entrypoint.sh`
- `git diff --check`
- ShellCheck 0.11.0 (no new findings compared with `master`)
- generated ed25519, nistp384, and RSA keys; signed and verified a Git commit with each parsed key ID
- ran `setup_commit_signing()` with an imported ed25519 key and verified the resulting signed commit
