### PR TITLE
fix: fail when no secret GPG key is imported

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -338,6 +338,11 @@ setup_commit_signing() {
   gpg --import --batch private.key
 
   GPG_KEY_ID=$(gpg --with-colons --list-secret-keys | awk -F: '$1 == "sec" { print $5; exit }')
+  if [ -z "$GPG_KEY_ID" ]; then
+    echo "ERROR: No secret GPG key was found after import"
+    rm private.key
+    exit 1
+  fi
   GPG_KEY_OWNER_NAME=$(gpg --list-secret-keys --keyid-format=long | grep  "uid" | sed "s/.\+] \(.\+\) <\(.\+\)>/\1/")
   GPG_KEY_OWNER_EMAIL=$(gpg --list-secret-keys --keyid-format=long | grep  "uid" | sed "s/.\+] \(.\+\) <\(.\+\)>/\2/")
   echo "Imported key information:"


### PR DESCRIPTION
## Summary

- stop commit-signing setup immediately when an import produces no secret key
- remove the temporary key file before returning the new error

## Why

GnuPG can successfully import public-only armored key data while `--list-secret-keys` returns no `sec` record. The existing setup then continues with an empty signing key ID and fails later without an actionable explanation.

This is the independent fail-fast follow-up discussed in #313.

## Verification

- reproduced the public-only import with GnuPG 2.5.21; the updated function exits with the explicit error and removes `private.key`
- verified the valid path with a freshly generated ed25519 private key, a signed Git commit, and `git verify-commit`
- `sh -n entrypoint.sh`
- ShellCheck diagnostics match `master` with no new finding
- `git diff --check`
